### PR TITLE
[Discard] Failed merge

### DIFF
--- a/wahid-dl.ipynb
+++ b/wahid-dl.ipynb
@@ -5,7 +5,7 @@
     "colab": {
       "provenance": [],
       "mount_file_id": "1pGxMZhSiEA7iPU8_WU3dRNcGS2ZkZ4rt",
-      "authorship_tag": "ABX9TyMWHBVCGQHUnDII2iwiU4hs",
+      "authorship_tag": "ABX9TyO9UzsDLbeR8fCV/ktcRWJW",
       "include_colab_link": true
     },
     "kernelspec": {
@@ -24,23 +24,26 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/Hung-i-Hsu/wahid-dl/blob/main/wahid-dl.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/chengmoxu/wahid-dl/blob/problems-fix/wahid-dl.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
       "cell_type": "markdown",
       "source": [
         "# wahid-dl\n",
-        "Build: wahid-dl.v2.1.20231117.googlecolab.1\n",
+        "Build: wahid-dl.v2.2.20240225.googlecolab.1\n",
         "\n",
         "## 使用說明\n",
-        "1. 請在Google Colab連線後執行環境設定，並允許存取Google Drive。\n",
+        "1. 請在Google Colab連線後執行環境設定，並允許完整存取Google Drive。\n",
         "2. 請依照您想要下載的影片類型執行相應的程式碼區塊。\n",
         "3. 下載的影片、音樂檔案將存到您的Google雲端之wahid-dl資料夾。\n",
-        "4. 若要使用Proxy，請在proxy_url=(' ')之兩個引號間填入Proxy IP以及Port，範例：proxy_url=('http://127.0.0.0:80')\n",
+        "4. 若要使用Proxy，請在proxy_url=(' ')之兩個引號間填入Proxy IP以及Port，範例：proxy_url=('https://www.google.com')\n",
         "\n",
         "## 版本更新說明\n",
-        "Improved audio download function."
+        "1. Fixed video wrong format issues.\n",
+        "2. Change the yt-dlp installation method to avoid outdated versions.\n",
+        "3. Added instructions to remove completed videos.\n",
+        "4. Description correction."
       ],
       "metadata": {
         "id": "WgfhLu22FEdn"
@@ -56,7 +59,8 @@
       "source": [
         "# 環境設定\n",
         "from google.colab import drive\n",
-        "!sudo apt install yt-dlp\n",
+        "!sudo wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp\n",
+        "!sudo chmod a+rx /usr/local/bin/yt-dlp\n",
         "!sudo apt install opus-tools\n",
         "!sudo apt install ffmpeg\n",
         "drive.mount('/content/MyDrive')\n",
@@ -74,7 +78,8 @@
         "else:\n",
         "  proxy_url=(\"--proxy \"+proxy_url)\n",
         "!yt-dlp {proxy_url} -c -S\"quality,res,fps,hdr:12,channels,size,br,asr\" --throttled-rate 100K --merge-output-format mp4 {url}\n",
-        "!cp *.mkv /content/MyDrive/MyDrive/wahid-dl-Download"
+        "!cp *.mp4 /content/MyDrive/MyDrive/wahid-dl-Download\n",
+        "!rm *.mp4"
       ],
       "metadata": {
         "id": "jTgOOXmTyIXs"
@@ -93,7 +98,8 @@
         "else:\n",
         "  proxy_url=(\"--proxy \"+proxy_url)\n",
         "!yt-dlp {proxy_url} --live-from-start --throttled-rate 100K {url}\n",
-        "!cp *.mkv /content/MyDrive/MyDrive/wahid-dl-Download"
+        "!cp *.mkv /content/MyDrive/MyDrive/wahid-dl-Download\n",
+        "!rm *.mkv"
       ],
       "metadata": {
         "id": "_26LBYq722yv"
@@ -112,7 +118,8 @@
         "else:\n",
         "  proxy_url=(\"--proxy \"+proxy_url)\n",
         "!yt-dlp {proxy_url} -c --throttled-rate 100K --extract-audio -f \"bestaudio[ext=m4a]\" {url}\n",
-        "!cp *.m4a /content/MyDrive/MyDrive/wahid-dl-Download"
+        "!cp *.m4a /content/MyDrive/MyDrive/wahid-dl-Download\n",
+        "!rm *.m4a"
       ],
       "metadata": {
         "id": "bci5hzon2d9i"


### PR DESCRIPTION
wahid-dl for Google Colab bugs fixed:
1. Fixed video wrong format issues.
2. Change the yt-dlp installation method to avoid outdated versions.
3. Added instructions to remove completed videos.
4. Description correction.