### PR TITLE
wahid-dl v6.2.20251227.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,34 @@
 ```
 Making video and audio download easily
 
-* For Windows/Linux/macOS Version Number: v5.4-20241230.1
-> feat: Call the new unified UI  
-> feat: Improved version information display  
-> style/fix: Removed old annotations/Removed old code  
- rename: Renamed wahid-dl Cookies Support to wahid-dl for Cookies Support  
+* For Windows/Linux Stable Version Number: v6.2.20251227.1
 
-* For Google Colab Version Number: wahid-dl-colab.v5.1.20240906.googlecolab.1
+> fix: Fixed a module call error that caused a crash 
+> fix: Corrected the version judgment RE 
+> fix: Removed platform check dependency and corrected the display of version information 
+> fix: Fixed incorrect text 
+> fix: Fixed the wrong loop 
+> fix: Corrected the return value method 
+> fix: Fixed incorrect display 
+> fix: Corrected the incorrect judgment leading to incorrect execution 
+> fix: Fixed yt-dlp not installing in wahid-dl development channel 
+> fix: Modified the judgment value to Boolean value
+> fix: Fixed install and uninstall functionality 
+> fix: Fixed folders not being removed by uninstaller
+> fix: Fixed incorrect folder removal 
+> fix: Temporarily remove system variable setting 
+> fix: Updated FFmpeg version 
+> feat: Removed support for Windows based on batchfile 
+> feat: Simplified the code and adjusted the functions 
+> feat: Changed to use unified packages 
+> feat: Removed the installer build tool 
+> feat: Call the new unified UI/UX 
+> feat: Called the unified function 
+> style: Changed the display text from "DEV" to "Develop Channel"
+> perf: Optimized code and function 
+> perf: Emporarily removed system variable setting and pipx install on Linux 
+
+* For Google Colab Stable Version Number: wahid-dl-colab.v5.1.20240906.googlecolab.1
 > fix: Fixed video wrong format issues  
 > fix: Changed the yt-dlp installation method to avoid outdated versions  
 > style: Description correction  

--- a/packages/checker/checking_ffmpeg.py
+++ b/packages/checker/checking_ffmpeg.py
@@ -41,7 +41,7 @@ def checking_old_ffmpeg_files_existed():
         ffprobe_exe_existed = False
     return (ffmpeg_exe_existed, ffplay_exe_existed, ffprobe_exe_existed)
 def checking_ffmpeg_version():
-    ffmpeg_exact_version_number = '7.1.1'
+    ffmpeg_exact_version_number = '8.0.1'
     ffmpeg_version_org_output = subprocess.getoutput ('ffmpeg -version')
     ffmpeg_version_detail = re.search(r'ffmpeg version (\d+\.\d+(?:\.\d+)?)', ffmpeg_version_org_output)
     if ffmpeg_version_detail:

--- a/packages/core/path.py
+++ b/packages/core/path.py
@@ -1,14 +1,20 @@
+def root():
+    path = 'C:\\'
+    return path
 def wahiddl_folder():
     path = 'C:\\wahid-dl'
     return path
 def wahiddl_DEV_folder():
     path = 'C:\\wahid-dl DEV'
     return path
+def old_ffmpeg_files():
+    path = ['C:\\wahid-dl\\ffmpeg.exe', 'C:\\wahid-dl\\ffplay.exe', 'C:\\wahid-dl\\ffprobe.exe']
+    return path
 def ffmpeg_folder():
     path = 'C:\\FFmpeg'
     return path
-def old_ffmpeg_files():
-    path = ['C:\\wahid-dl\\ffmpeg.exe', 'C:\\wahid-dl\\ffplay.exe', 'C:\\wahid-dl\\ffprobe.exe']
+def ffmpeg_files():
+    path = ['C:\\FFmpeg\\ffmpeg.exe', 'C:\\FFmpeg\\ffplay.exe', 'C:\\FFmpeg\\ffprobe.exe']
     return path
 def wahiddl_ytdlp():
     path = 'C:\\wahid-dl\\yt-dlp.exe'

--- a/packages/core/path.py
+++ b/packages/core/path.py
@@ -46,3 +46,6 @@ def wahiddl_readme():
 def wahiddl_DEV_readme():
     path = 'C:\\wahid-dl DEV\\README.md'
     return path
+def wahiddl_url_list():
+    path = 'C:\\wahid-dl DEV\\url_list.txt'
+    return path

--- a/packages/core/path.py
+++ b/packages/core/path.py
@@ -15,3 +15,28 @@ def wahiddl_ytdlp():
     return path
 def wahiddl_DEV_ytdlp():
     path = 'C:\\wahid-dl DEV\\yt-dlp.exe'
+    return path
+def wahiddl_packages():
+    path = 'C:\\wahid-dl\\packages'
+    return path
+def wahiddl_DEV_packages():
+    path = 'C:\\wahid-dl DEV\\packages'
+    return path
+def wahiddl_bat():
+    path = 'C:\\wahid-dl\\bat'
+    return path
+def wahiddl_DEV_bat():
+    path = 'C:\\wahid-dl DEV\\bat'
+    return path
+def wahiddl_tool():
+    path = 'C:\\wahid-dl\\tool'
+    return path
+def wahiddl_DEV_tool():
+    path = 'C:\\wahid-dl DEV\\tool'
+    return path
+def wahiddl_readme():
+    path = 'C:\\wahid-dl\\README.md'
+    return path
+def wahiddl_DEV_readme():
+    path = 'C:\\wahid-dl DEV\\README.md'
+    return path

--- a/packages/core/url.py
+++ b/packages/core/url.py
@@ -1,0 +1,9 @@
+def wahiddl_main_branch():
+    url = 'https://codeload.github.com/chengmoxu/wahid-dl/zip/refs/heads/main'
+    return url
+def wahiddl_DEV_branch():
+    url = 'https://codeload.github.com/chengmoxu/wahid-dl/zip/refs/heads/develop'
+    return url
+def ffmpeg():
+    url = 'https://github.com/GyanD/codexffmpeg/releases/download/7.1.1/ffmpeg-7.1.1-full_build.zip'
+    return url

--- a/packages/core/url.py
+++ b/packages/core/url.py
@@ -5,5 +5,5 @@ def wahiddl_DEV_branch():
     url = 'https://codeload.github.com/chengmoxu/wahid-dl/zip/refs/heads/develop'
     return url
 def ffmpeg():
-    url = 'https://github.com/GyanD/codexffmpeg/releases/download/7.1.1/ffmpeg-7.1.1-full_build.zip'
+    url = 'https://github.com/GyanD/codexffmpeg/releases/download/8.0.1/ffmpeg-8.0.1-full_build.zip'
     return url

--- a/packages/core/version_info.py
+++ b/packages/core/version_info.py
@@ -1,6 +1,6 @@
 #Platform info
 import sys
-def vi_platform():
+def vi_platform(): #current execution platform detection function
     if sys.platform  == "win32":
         system_os = "Windows"
         return system_os
@@ -11,10 +11,10 @@ def vi_platform():
         system_os = "macOS"
         return system_os
 #Wahid-dl info
-channel = "Stable"
-number = "6.0"
-build_number = "20250627.1"
+channel = "Develop"
+number = "6.1"
+build_number = "20250825.1"
 language = "Python"
 def vi_detail():
-    vi = [channel, number, build_number, language]
+    vi = [channel, number, build_number, language] #vi = version info
     return vi

--- a/packages/core/version_info.py
+++ b/packages/core/version_info.py
@@ -13,7 +13,7 @@ def vi_platform(): #current execution platform detection function
 #Wahid-dl info
 channel = "Develop"
 number = "6.1"
-build_number = "20250825.1"
+build_number = "20250827.1"
 language = "Python"
 def vi_detail():
     vi = [channel, number, build_number, language] #vi = version info

--- a/packages/core/version_info.py
+++ b/packages/core/version_info.py
@@ -11,9 +11,9 @@ def vi_platform(): #current execution platform detection function
         system_os = "macOS"
         return system_os
 #Wahid-dl info
-channel = "Develop"
-number = "6.1"
-build_number = "20250827.2"
+channel = "Stable"
+number = "6.2"
+build_number = "20251227.1"
 language = "Python"
 def vi_detail():
     vi = [channel, number, build_number, language] #vi = version info

--- a/packages/core/version_info.py
+++ b/packages/core/version_info.py
@@ -13,7 +13,7 @@ def vi_platform(): #current execution platform detection function
 #Wahid-dl info
 channel = "Develop"
 number = "6.1"
-build_number = "20250827.1"
+build_number = "20250827.2"
 language = "Python"
 def vi_detail():
     vi = [channel, number, build_number, language] #vi = version info

--- a/packages/function/wahiddl.py
+++ b/packages/function/wahiddl.py
@@ -1,8 +1,8 @@
 import os
 from packages.core import ui
 def main():
-    print(ui.ASCII_art())
-    print(ui.ui_title_wahiddl())
+    print(ui.ASCII_art()) #unified UI function: ASCII art
+    print(ui.ui_title_wahiddl()) #unified UI function: function title
     print ('--------------------------------------------------')
     mode = ""
     while mode == "":

--- a/packages/function/wahiddl.py
+++ b/packages/function/wahiddl.py
@@ -1,5 +1,6 @@
 import os
 from packages.core import ui
+from packages.core import path #unified path function
 def main():
     print(ui.ASCII_art()) #unified UI function: ASCII art
     print(ui.ui_title_wahiddl()) #unified UI function: function title
@@ -19,7 +20,7 @@ def main():
         elif userinput_judge == False:
             if userinput.startswith("http") == True:
                 ui.ui_start()
-                os.chdir ('C:\\wahid-dl')
+                os.chdir (path.wahiddl_folder())
                 downloadcommand = str (('yt-dlp -c -S"quality,res,fps,hdr:12,channels,size,br,asr" --throttled-rate 100K --merge-output-format mp4 --ffmpeg-location "C:\\FFmpeg" ') + userinput)
                 os.system (downloadcommand)
                 ui.ui_complete()

--- a/packages/function/wahiddl_CS.py
+++ b/packages/function/wahiddl_CS.py
@@ -1,5 +1,6 @@
 import os
 from packages.core import ui
+from packages.core import path #unified path function
 def main():
     print(ui.ASCII_art())
     print(ui.ui_title_wahiddl_CS())
@@ -19,7 +20,7 @@ def main():
         elif userinput_judge == False:
             if userinput.startswith("http") == True:
                 ui.ui_start()
-                os.chdir ('C:\\wahid-dl')
+                os.chdir (path.wahiddl_folder())
                 downloadcommand = str (('yt-dlp --cookies-from-browser chrome -c -S"quality,res,fps,hdr:12,channels,size,br,asr" --throttled-rate 100K --merge-output-format mp4 --ffmpeg-location "C:\\FFmpeg" ') + userinput)
                 os.system (downloadcommand)
                 ui.ui_complete()

--- a/packages/function/wahiddl_FCT.py
+++ b/packages/function/wahiddl_FCT.py
@@ -1,5 +1,6 @@
 import os
 from packages.core import ui
+from packages.core import path #unified path function
 def main():
     print(ui.ASCII_art())
     print(ui.ui_title_wahiddl_FCT())
@@ -19,7 +20,7 @@ def main():
         elif userinput_judge == False:
             if userinput.startswith("http") == True:
                 ui.ui_start()
-                os.chdir ('C:\\wahid-dl')
+                os.chdir (path.wahiddl_folder())
                 testcommand = str (('yt-dlp -F ') + userinput)
                 os.system (testcommand)
                 ui.ui_complete()

--- a/packages/function/wahiddl_QS.py
+++ b/packages/function/wahiddl_QS.py
@@ -1,5 +1,6 @@
 import os
 from packages.core import ui
+from packages.core import path #unified path function
 def main():
     print(ui.ASCII_art())
     print(ui.ui_title_wahiddl_QS())
@@ -19,7 +20,7 @@ def main():
         elif userinput_judge == False:
             if userinput.startswith("http") == True:
                 ui.ui_start()
-                os.chdir ('C:\\wahid-dl')
+                os.chdir (path.wahiddl_folder())
                 testcommand = str (('yt-dlp -F ') + userinput)
                 os.system (testcommand)
                 print ('請記下您想要下載的影片畫質ID，並於下方輸入')

--- a/packages/function/wahiddl_audio.py
+++ b/packages/function/wahiddl_audio.py
@@ -1,5 +1,6 @@
 import os
 from packages.core import ui
+from packages.core import path #unified path function
 def main():
     print(ui.ASCII_art())
     print(ui.ui_title_wahiddl_audio())
@@ -19,7 +20,7 @@ def main():
         elif userinput_judge == False:
             if userinput.startswith("http") == True:
                 ui.ui_start()
-                os.chdir ('C:\\wahid-dl')
+                os.chdir (path.wahiddl_folder())
                 downloadcommand = str (('yt-dlp -c --throttled-rate 100K --extract-audio -f "bestaudio[ext=m4a]" --ffmpeg-location "C:\\FFmpeg" ') + userinput)
                 os.system (downloadcommand)
                 ui.ui_complete()

--- a/packages/function/wahiddl_devmode.py
+++ b/packages/function/wahiddl_devmode.py
@@ -2,6 +2,7 @@ import os
 import sys
 from packages.core import ui
 from packages.core import version_info
+from packages.core import path #unified path function
 def devmode():
     print(ui.ASCII_art())
     print(ui.ui_title_wahiddl_devmode())
@@ -22,7 +23,7 @@ def devmode():
             if userinput.startswith("yt-dlp") == True:
                 ui.ui_start()
                 if sys.platform == "win32":
-                    os.chdir ('C:\\wahid-dl')
+                    os.chdir (path.wahiddl_folder())
                 elif sys.platform == "linux":
                     os.chdir ('$HOME/wahid-dl')
                 else:

--- a/packages/function/wahiddl_list.py
+++ b/packages/function/wahiddl_list.py
@@ -1,5 +1,6 @@
 import os
 from packages.core import ui
+from packages.core import path #unified path function
 def main():
     print(ui.ASCII_art())
     print(ui.ui_title_wahiddl_list())
@@ -16,14 +17,14 @@ def main():
             elif userinput == "1":
                 x = 0
                 for x in range (0,2,1):
-                    if os.path.isfile ('C:\\wahid-dl\\url_list.txt') == True:
+                    if os.path.isfile (path.wahiddl_url_list()) == True:
                         print ("存在url_list.txt")
                         print ('刪除存在的url_list.txt，並自動建立新的url_list.txt，請輸入1')
                         print ('保留存在的url_list.txt，並以此清單進行下載，請輸入2')
                         choice = input ('請選擇處理方式：')
                         if choice == 1:
-                            os.remove ('C:\\wahid-dl\\url_list.txt')
-                            os.open('C:\\wahid-dl\\url_list.txt', os.O_RDWR|os.O_CREAT)
+                            os.remove (path.wahiddl_url_list())
+                            os.open(path.wahiddl_url_list(), os.O_RDWR|os.O_CREAT)
                             print ('請在對於url_list.txt編輯完成後再按下任一鍵以進行下載')
                             os.system ('pause')
                             break
@@ -36,12 +37,12 @@ def main():
                     else:
                         print ("不存在url_list.txt")
                         print ('已自動建立新的url_list.txt')
-                        os.open('C:\\wahid-dl\\url_list.txt', os.O_RDWR|os.O_CREAT)
+                        os.open(path.wahiddl_url_list(), os.O_RDWR|os.O_CREAT)
                         print ('請在對於url_list.txt編輯完成後再按下任一鍵以進行下載')
                         os.system ('pause')
                         break
                 ui.ui_start()
-                os.chdir ('C:\\wahid-dl')
+                os.chdir (path.wahiddl_folder())
                 downloadcommand = str (('yt-dlp --batch-file url_list.txt -c -S"quality,res,fps,hdr:12,channels,size,br,asr" --throttled-rate 100K --merge-output-format mp4 --ffmpeg-location "C:\\FFmpeg"'))
                 os.system (downloadcommand)
                 ui.ui_complete()

--- a/packages/function/wahiddl_live.py
+++ b/packages/function/wahiddl_live.py
@@ -1,5 +1,6 @@
 import os
 from packages.core import ui
+from packages.core import path #unified path function
 def main():
     print(ui.ASCII_art())
     print(ui.ui_title_wahiddl_live())
@@ -19,7 +20,7 @@ def main():
         elif userinput_judge == False:
             if userinput.startswith("http") == True:
                 ui.ui_start()
-                os.chdir ('C:\\wahid-dl')
+                os.chdir (path.wahiddl_folder())
                 downloadcommand = str (('yt-dlp -c --live-from-start -S"quality,res,fps,hdr:12,channels,size,br,asr" --throttled-rate 100K --merge-output-format mp4 --ffmpeg-location "C:\\FFmpeg" ') + userinput)
                 os.system (downloadcommand)
                 ui.ui_complete()

--- a/packages/function/wahiddl_subtitle.py
+++ b/packages/function/wahiddl_subtitle.py
@@ -1,5 +1,6 @@
 import os
 from packages.core import ui
+from packages.core import path #unified path function
 def main():
     print(ui.ASCII_art())
     print(ui.ui_title_wahiddl_subtitle())
@@ -19,7 +20,7 @@ def main():
         elif userinput_judge == False:
             if userinput.startswith("http") == True:
                 ui.ui_start()
-                os.chdir ('C:\\wahid-dl')
+                os.chdir (path.wahiddl_folder())
                 testcommand = str (('yt-dlp --list-subs ') + userinput)
                 os.system (testcommand)
                 print ('請記下您想要下載的影片字幕Language，並於下方輸入')

--- a/packages/installer/installer_ffmpeg.py
+++ b/packages/installer/installer_ffmpeg.py
@@ -21,13 +21,13 @@ def installer_ffmpeg():
     #os.system ('setx PATH "FFmpeg;C:\\FFmpeg\\"') 
     #NOTICE: A severe flaw exists that could potentially lead to the removal of all system environment variables.
     ffmpeg_updates_file_path = 'C:\\FFmpeg\\ffmpeg.zip'
-    if os.path.isfile (ffmpeg_updates_file_path) == True:
+    try:
         os.remove (ffmpeg_updates_file_path)
         print (f"更新資料 '{ffmpeg_updates_file_path}' 已刪除")
-    else:
+    except:
         print (f"更新資料 '{ffmpeg_updates_file_path}' 已不存在")
-    if os.path.exists (ffmpegunzip_folder_name):
+    try:
         shutil.rmtree (ffmpegunzip_folder_name)
         print (f"更新資料夾 '{ffmpegunzip_folder_name}' 已刪除")
-    else:
+    except:
         print (f"更新資料 '{ffmpegunzip_folder_name}' 已不存在")

--- a/packages/installer/installer_ffmpeg.py
+++ b/packages/installer/installer_ffmpeg.py
@@ -1,9 +1,11 @@
 import os
 import glob
 import shutil
+from packages.core import path #unified path function
+from packages.core import url #unified url function
 def installer_ffmpeg():
-    os.chdir ('C:\\FFmpeg')
-    os.system ('curl -L -o ffmpeg.zip https://github.com/GyanD/codexffmpeg/releases/download/7.1.1/ffmpeg-7.1.1-full_build.zip')
+    os.chdir (path.ffmpeg_folder())
+    os.system ('curl -L -o ffmpeg.zip ' + url.ffmpeg())
     ffmpegunzip_folder_name = 'FFmpeg-unzip'
     if not os.path.exists (ffmpegunzip_folder_name):
         os.mkdir (ffmpegunzip_folder_name)
@@ -12,11 +14,12 @@ def installer_ffmpeg():
         print (f"'{ffmpegunzip_folder_name}' 資料夾已存在")
     os.system ('tar -zxvf ffmpeg.zip -C "C:\\FFmpeg\\FFmpeg-unzip"')
     ffmpeg_updatesfiles_folder = "C:\\FFmpeg\\FFmpeg-unzip\\ffmpeg-7.1.1-full_build\\bin\\"
-    ffmpeg_dst_folder = 'C:\\FFmpeg\\'
+    ffmpeg_dst_folder = path.ffmpeg_folder()
     ffmpeg_exe_files = glob.glob (ffmpeg_updatesfiles_folder + "*.exe")
     for ffmpeg_exe_file in ffmpeg_exe_files:
         shutil.move (ffmpeg_exe_file, ffmpeg_dst_folder)
-    os.system ('setx PATH "FFmpeg;C:\\FFmpeg\\"')
+    #os.system ('setx PATH "FFmpeg;C:\\FFmpeg\\"') 
+    #NOTICE: A severe flaw exists that could potentially lead to the removal of all system environment variables.
     ffmpeg_updates_file_path = 'C:\\FFmpeg\\ffmpeg.zip'
     if os.path.isfile (ffmpeg_updates_file_path) == True:
         os.remove (ffmpeg_updates_file_path)

--- a/packages/installer/installer_ffmpeg.py
+++ b/packages/installer/installer_ffmpeg.py
@@ -7,10 +7,10 @@ def installer_ffmpeg():
     os.chdir (path.ffmpeg_folder())
     os.system ('curl -L -o ffmpeg.zip ' + url.ffmpeg())
     ffmpegunzip_folder_name = 'FFmpeg-unzip'
-    if not os.path.exists (ffmpegunzip_folder_name):
+    try:
         os.mkdir (ffmpegunzip_folder_name)
         print (f"'{ffmpegunzip_folder_name}' 資料夾已建立")
-    else:
+    except:
         print (f"'{ffmpegunzip_folder_name}' 資料夾已存在")
     os.system ('tar -zxvf ffmpeg.zip -C "C:\\FFmpeg\\FFmpeg-unzip"')
     ffmpeg_updatesfiles_folder = "C:\\FFmpeg\\FFmpeg-unzip\\ffmpeg-7.1.1-full_build\\bin\\"

--- a/packages/installer/installer_ffmpeg.py
+++ b/packages/installer/installer_ffmpeg.py
@@ -13,7 +13,7 @@ def installer_ffmpeg():
     except:
         print (f"'{ffmpegunzip_folder_name}' 資料夾已存在")
     os.system ('tar -zxvf ffmpeg.zip -C "C:\\FFmpeg\\FFmpeg-unzip"')
-    ffmpeg_updatesfiles_folder = "C:\\FFmpeg\\FFmpeg-unzip\\ffmpeg-7.1.1-full_build\\bin\\"
+    ffmpeg_updatesfiles_folder = "C:\\FFmpeg\\FFmpeg-unzip\\ffmpeg-8.0.1-full_build\\bin\\"
     ffmpeg_dst_folder = path.ffmpeg_folder()
     ffmpeg_exe_files = glob.glob (ffmpeg_updatesfiles_folder + "*.exe")
     for ffmpeg_exe_file in ffmpeg_exe_files:

--- a/packages/installer/installer_wahiddl.py
+++ b/packages/installer/installer_wahiddl.py
@@ -6,15 +6,14 @@ def installer_wahiddl_install():
     os.chdir (path.wahiddl_folder())
     os.system ('curl -L -o updates.zip ' + url.wahiddl_main_branch())
     updates_folder_name = 'updates'
-    if not os.path.exists (updates_folder_name):
+    try:
         os.mkdir (updates_folder_name)
         print (f"{updates_folder_name} 更新資料之暫存資料夾已建立")
-    elif os.path.exists (updates_folder_name):
+    except:
         print (f"{updates_folder_name} 更新資料之暫存資料夾已存在")
     print ('解壓縮 wahid-dl 更新資料')
     os.system ('tar -zxvf updates.zip -C "C:\\wahid-dl\\updates"')
     wahiddl_updatesfiles_folder = 'C:\\wahid-dl\\updates\\wahid-dl-main\\'
-    wahiddl_folder = 'C:\\wahid-dl\\'
     for item in os.listdir(wahiddl_updatesfiles_folder):
         s = os.path.join(wahiddl_updatesfiles_folder, item)
         d = os.path.join(path.wahiddl_folder(), item)

--- a/packages/installer/installer_wahiddl.py
+++ b/packages/installer/installer_wahiddl.py
@@ -1,8 +1,10 @@
 import os
 import shutil
+from packages.core import path #unified path function
+from packages.core import url #unified url function
 def installer_wahiddl_install():
-    os.chdir ('C:\\wahid-dl')
-    os.system ('curl -L -o updates.zip https://codeload.github.com/chengmoxu/wahid-dl/zip/refs/heads/main')
+    os.chdir (path.wahiddl_folder())
+    os.system ('curl -L -o updates.zip ' + url.wahiddl_main_branch())
     updates_folder_name = 'updates'
     if not os.path.exists (updates_folder_name):
         os.mkdir (updates_folder_name)
@@ -15,7 +17,7 @@ def installer_wahiddl_install():
     wahiddl_folder = 'C:\\wahid-dl\\'
     for item in os.listdir(wahiddl_updatesfiles_folder):
         s = os.path.join(wahiddl_updatesfiles_folder, item)
-        d = os.path.join(wahiddl_folder, item)
+        d = os.path.join(path.wahiddl_folder(), item)
         if os.path.isdir(s):
             shutil.copytree(s, d, dirs_exist_ok=True)
         else:

--- a/packages/installer/installer_wahiddl_DEV.py
+++ b/packages/installer/installer_wahiddl_DEV.py
@@ -6,10 +6,10 @@ def installer_wahiddl_DEV_install():
     os.chdir (path.wahiddl_DEV_folder())
     os.system ('curl -L -o updates.zip ' + url.wahiddl_DEV_branch())
     updates_folder_name = 'updates'
-    if not os.path.exists (updates_folder_name):
+    try:
         os.mkdir (updates_folder_name)
         print (f"{updates_folder_name} 更新資料之暫存資料夾已建立")
-    elif os.path.exists (updates_folder_name):
+    except:
         print (f"{updates_folder_name} 更新資料之暫存資料夾已存在")
     print ('解壓縮 wahid-dl Develop Channel 更新資料')
     os.system ('tar -zxvf updates.zip -C "C:\\wahid-dl DEV\\updates"')

--- a/packages/installer/installer_wahiddl_DEV.py
+++ b/packages/installer/installer_wahiddl_DEV.py
@@ -14,7 +14,6 @@ def installer_wahiddl_DEV_install():
     print ('解壓縮 wahid-dl Develop Channel 更新資料')
     os.system ('tar -zxvf updates.zip -C "C:\\wahid-dl DEV\\updates"')
     wahiddl_DEV_updatesfiles_folder = 'C:\\wahid-dl DEV\\updates\\wahid-dl-develop\\'
-    wahiddl_DEV_folder = 'C:\\wahid-dl DEV\\'
     for item in os.listdir(wahiddl_DEV_updatesfiles_folder):
         s = os.path.join(wahiddl_DEV_updatesfiles_folder, item)
         d = os.path.join(path.wahiddl_DEV_folder(), item)

--- a/packages/installer/installer_wahiddl_DEV.py
+++ b/packages/installer/installer_wahiddl_DEV.py
@@ -1,8 +1,10 @@
 import os
 import shutil
+from packages.core import path #unified path function
+from packages.core import url #unified url function
 def installer_wahiddl_DEV_install():
-    os.chdir ('C:\\wahid-dl DEV')
-    os.system ('curl -L -o updates.zip https://codeload.github.com/chengmoxu/wahid-dl/zip/refs/heads/develop')
+    os.chdir (path.wahiddl_DEV_folder())
+    os.system ('curl -L -o updates.zip ' + url.wahiddl_DEV_branch())
     updates_folder_name = 'updates'
     if not os.path.exists (updates_folder_name):
         os.mkdir (updates_folder_name)
@@ -15,7 +17,7 @@ def installer_wahiddl_DEV_install():
     wahiddl_DEV_folder = 'C:\\wahid-dl DEV\\'
     for item in os.listdir(wahiddl_DEV_updatesfiles_folder):
         s = os.path.join(wahiddl_DEV_updatesfiles_folder, item)
-        d = os.path.join(wahiddl_DEV_folder, item)
+        d = os.path.join(path.wahiddl_DEV_folder(), item)
         if os.path.isdir(s):
             shutil.copytree(s, d, dirs_exist_ok=True)
         else:

--- a/packages/uninstaller/uninstaller_ffmpeg.py
+++ b/packages/uninstaller/uninstaller_ffmpeg.py
@@ -1,41 +1,42 @@
 import os
+from packages.core import path #unified path function
 def uninstaller_ffmpeg():
-    os.chdir ('C:\\FFmpeg')
-    if os.path.isfile ('C:\\FFmpeg\\ffmpeg.exe') == True:
-        os.remove ('C:\\FFmpeg\\ffmpeg.exe')
+    os.chdir (path.ffmpeg_folder())
+    try:
+        os.remove (path.ffmpeg_files()[0])
         print ("已刪除新式舊版的 ffmpeg.exe")
-    elif not os.path.isfile ('C:\\FFmpeg\\ffmpeg.exe') == True:
+    except:
         print ("已不存在新式舊版 ffmpeg.exe")
-    if os.path.isfile ('C:\\FFmpeg\\ffplay.exe') == True:
-        os.remove ('C:\\FFmpeg\\ffplay.exe')
+    try:
+        os.remove (path.ffmpeg_files()[1])
         print ("已刪除新式舊版的 ffplay.exe")
-    elif not os.path.isfile ('C:\\FFmpeg\\ffplay.exe') == True:
+    except:
         print ("已不存在新式舊版 ffplay.exe")
-    if os.path.isfile ('C:\\FFmpeg\\ffprobe.exe') == True:
-        os.remove ('C:\\FFmpeg\\ffprobe.exe')
+    try:
+        os.remove (path.ffmpeg_files()[2])
         print ("已刪除新式舊版的 ffprobe.exe")
-    elif not os.path.isfile ('C:\\FFmpeg\\ffprobe.exe') == True:
+    except:
         print ("已不存在新式舊版 ffprobe.exe")
-    os.chdir ('C:\\')
-    if os.path.exists ('C:\\FFmpeg\\') == True:
-        os.rmdir ('C:\\FFmpeg\\')
+    os.chdir (path.root())
+    try:
+        os.rmdir (path.ffmpeg_folder())
         print ("已刪除 FFmpeg 資料夾")
-    elif not os.path.exists ('C:\\FFmpeg\\') == True:
+    except:
         print ("已不存在 FFmpeg 資料夾")
 def uninstaller_old_ffmpeg():
-    os.chdir ('C:\\wahid-dl')
-    if os.path.isfile ('C:\\wahid-dl\\ffmpeg.exe') == True:
-        os.remove ('C:\\wahid-dl\\ffmpeg.exe')
+    os.chdir (path.wahiddl_folder())
+    try:
+        os.remove (path.old_ffmpeg_files()[0])
         print ("已刪除舊式舊版的 ffmpeg.exe")
-    elif not os.path.isfile ('C:\\wahid-dl\\ffmpeg.exe') == True:
+    except:
         print ("已不存在舊式舊版 ffmpeg.exe")
-    if os.path.isfile ('C:\\wahid-dl\\ffplay.exe') == True:
-        os.remove ('C:\\wahid-dl\\ffplay.exe')
+    try:
+        os.remove (path.old_ffmpeg_files()[1])
         print ("已刪除舊式舊版的 ffplay.exe")
-    elif not os.path.isfile ('C:\\wahid-dl\\ffplay.exe') == True:
+    except:
         print ("已不存在舊式舊版 ffplay.exe")
-    if os.path.isfile ('C:\\wahid-dl\\ffprobe.exe') == True:
-        os.remove ('C:\\wahid-dl\\ffprobe.exe')
+    try:
+        os.remove (path.old_ffmpeg_files()[2])
         print ("已刪除舊式舊版的 ffprobe.exe")
-    elif not os.path.isfile ('C:\\wahid-dl\\ffprobe.exe') == True:
+    except:
         print ("已不存在舊式舊版 ffprobe.exe")

--- a/packages/uninstaller/uninstaller_wahiddl_DEV.py
+++ b/packages/uninstaller/uninstaller_wahiddl_DEV.py
@@ -6,35 +6,35 @@ def uninstaller_wahiddl_DEV_uninstall():
     os.chdir (path.wahiddl_DEV_folder())
     wahiddl_DEV_old_bat_files = glob.glob ("*.bat")
     for bat_file in wahiddl_DEV_old_bat_files:
-        if os.path.exists (bat_file):
+        try:
             os.remove (bat_file)
             print (f"已刪除 wahid-dl Develop Channel 舊版的{bat_file}")
-        else:
+        except:
             print ("不存在 wahid-dl Develop Channel 舊版之 .bat 檔案")
     wahiddl_DEV_old_py_files = glob.glob ("*.py")
     for py_file in wahiddl_DEV_old_py_files:
-        if os.path.exists (py_file):
+        try:
             os.remove (py_file)
             print (f"已刪除 wahid-dl Develop Channel 舊版的{py_file}")
-        else:
+        except:
             print ("不存在 wahid-dl Develop Channel 舊版之 .py 檔案")
-    if os.path.exists (path.wahiddl_DEV_packages()):
+    try:
         shutil.rmtree(path.wahiddl_DEV_packages())
-        print (f"已刪除 wahid-dl Develop Channel 舊版的 packages")
-    elif not os.path.exists (path.wahiddl_DEV_packages()):
-        print (f"已不存在 wahid-dl Develop Channel 舊版的 packages")
-    if os.path.exists (path.wahiddl_DEV_bat()):
+        print ("已刪除 wahid-dl Develop Channel 舊版的 packages")
+    except:
+        print ("已不存在 wahid-dl Develop Channel 舊版的 packages")
+    try:
         shutil.rmtree(path.wahiddl_DEV_bat())
-        print (f"已刪除 wahid-dl Develop Channel 的早期版本支援")
-    elif not os.path.exists (path.wahiddl_DEV_bat()):
-        print (f"已不存在 wahid-dl Develop Channel 的早期版本支援")
-    if os.path.exists (path.wahiddl_DEV_tool()):
+        print ("已刪除 wahid-dl Develop Channel 的早期版本支援")
+    except:
+        print ("已不存在 wahid-dl Develop Channel 的早期版本支援")
+    try:
         shutil.rmtree(path.wahiddl_DEV_tool())
-        print (f"已刪除 wahid-dl Develop Channel 的安裝檔打包工具資料夾")
-    elif not os.path.exists (path.wahiddl_DEV_tool()):
-        print (f"已不存在 wahid-dl Develop Channel 的安裝檔打包工具資料夾")
-    if os.path.isfile (path.wahiddl_DEV_readme()) == True:
+        print ("已刪除 wahid-dl Develop Channel 的安裝檔打包工具資料夾")
+    except:
+        print ("已不存在 wahid-dl Develop Channel 的安裝檔打包工具資料夾")
+    try:
         os.remove (path.wahiddl_DEV_readme())
-        print (f"已刪除 README.md")
-    elif not os.path.isfile (path.wahiddl_DEV_readme()) == True:
-        print (f"已不存在 README.md")
+        print ("已刪除 README.md")
+    except:
+        print ("已不存在 README.md")

--- a/packages/uninstaller/uninstaller_wahiddl_DEV.py
+++ b/packages/uninstaller/uninstaller_wahiddl_DEV.py
@@ -1,8 +1,9 @@
 import os
 import glob
 import shutil
+from packages.core import path #unified path function
 def uninstaller_wahiddl_DEV_uninstall():
-    os.chdir ("C:\\wahid-dl DEV")
+    os.chdir (path.wahiddl_DEV_folder())
     wahiddl_DEV_old_bat_files = glob.glob ("*.bat")
     for bat_file in wahiddl_DEV_old_bat_files:
         if os.path.exists (bat_file):
@@ -17,18 +18,23 @@ def uninstaller_wahiddl_DEV_uninstall():
             print (f"已刪除 wahid-dl Develop Channel 舊版的{py_file}")
         else:
             print ("不存在 wahid-dl Develop Channel 舊版之 .py 檔案")
-    if os.path.exists ("C:\\wahid-dl DEV\\packages"):
-        shutil.rmtree("C:\\wahid-dl DEV\\packages")
+    if os.path.exists (path.wahiddl_DEV_packages()):
+        shutil.rmtree(path.wahiddl_DEV_packages())
         print (f"已刪除 wahid-dl Develop Channel 舊版的 packages")
-    elif not os.path.exists ("C:\\wahid-dl DEV\\packages"):
+    elif not os.path.exists (path.wahiddl_DEV_packages()):
         print (f"已不存在 wahid-dl Develop Channel 舊版的 packages")
-    if os.path.exists ("C:\\wahid-dl DEV\\bat"):
-        shutil.rmtree("C:\\wahid-dl DEV\\bat")
+    if os.path.exists (path.wahiddl_DEV_bat()):
+        shutil.rmtree(path.wahiddl_DEV_bat())
         print (f"已刪除 wahid-dl Develop Channel 的早期版本支援")
-    elif not os.path.exists ("C:\\wahid-dl DEV\\bat"):
+    elif not os.path.exists (path.wahiddl_DEV_bat()):
         print (f"已不存在 wahid-dl Develop Channel 的早期版本支援")
-    if os.path.exists ("C:\\wahid-dl DEV\\tool"):
-        shutil.rmtree("C:\\wahid-dl DEV\\tool")
+    if os.path.exists (path.wahiddl_DEV_tool()):
+        shutil.rmtree(path.wahiddl_DEV_tool())
         print (f"已刪除 wahid-dl Develop Channel 的安裝檔打包工具資料夾")
-    elif not os.path.exists ("C:\\wahid-dl DEV\\tool"):
+    elif not os.path.exists (path.wahiddl_DEV_tool()):
         print (f"已不存在 wahid-dl Develop Channel 的安裝檔打包工具資料夾")
+    if os.path.isfile (path.wahiddl_DEV_readme()) == True:
+        os.remove (path.wahiddl_DEV_readme())
+        print (f"已刪除 README.md")
+    elif not os.path.isfile (path.wahiddl_DEV_readme()) == True:
+        print (f"已不存在 README.md")

--- a/packages/uninstaller/uninstaller_ytdlp.py
+++ b/packages/uninstaller/uninstaller_ytdlp.py
@@ -1,15 +1,16 @@
 import os
+from packages.core import path #unified path function
 def uninstaller_wahiddl_ytdlp_uninstall():
-    os.chdir ('C:\\wahid-dl')
-    if os.path.isfile ('C:\\wahid-dl\\yt-dlp.exe') == True:
-        os.remove ('C:\\wahid-dl\\yt-dlp.exe')
+    os.chdir (path.wahiddl_folder())
+    if os.path.isfile (path.wahiddl_ytdlp()) == True:
+        os.remove (path.wahiddl_ytdlp())
         print ("已刪除 yt-dlp.exe")
-    elif not os.path.isfile ('C:\\wahid-dl\\yt-dlp.exe') == True:
+    elif not os.path.isfile (path.wahiddl_ytdlp()) == True:
         print ("不存在 yt-dlp.exe")
 def uninstaller_wahiddl_DEV_ytdlp_uninstall():
-    os.chdir ('C:\\wahid-dl DEV')
-    if os.path.isfile ('C:\\wahid-dl DEV\\yt-dlp.exe') == True:
-        os.remove ('C:\\wahid-dl DEV\\yt-dlp.exe')
+    os.chdir (path.wahiddl_DEV_folder())
+    if os.path.isfile (path.wahiddl_DEV_ytdlp()) == True:
+        os.remove (path.wahiddl_DEV_ytdlp())
         print ("已刪除 yt-dlp.exe")
-    elif not os.path.isfile ('C:\\wahid-dl DEV\\yt-dlp.exe') == True:
+    elif not os.path.isfile (path.wahiddl_DEV_ytdlp()) == True:
         print ("不存在 yt-dlp.exe")

--- a/packages/uninstaller/uninstaller_ytdlp.py
+++ b/packages/uninstaller/uninstaller_ytdlp.py
@@ -5,7 +5,6 @@ def uninstaller_wahiddl_ytdlp_uninstall():
         os.remove ('C:\\wahid-dl\\yt-dlp.exe')
         print ("已刪除 yt-dlp.exe")
     elif not os.path.isfile ('C:\\wahid-dl\\yt-dlp.exe') == True:
-        os.remove ('C:\\wahid-dl\\yt-dlp.exe')
         print ("不存在 yt-dlp.exe")
 def uninstaller_wahiddl_DEV_ytdlp_uninstall():
     os.chdir ('C:\\wahid-dl DEV')
@@ -13,5 +12,4 @@ def uninstaller_wahiddl_DEV_ytdlp_uninstall():
         os.remove ('C:\\wahid-dl DEV\\yt-dlp.exe')
         print ("已刪除 yt-dlp.exe")
     elif not os.path.isfile ('C:\\wahid-dl DEV\\yt-dlp.exe') == True:
-        os.remove ('C:\\wahid-dl DEV\\yt-dlp.exe')
         print ("不存在 yt-dlp.exe")

--- a/packages/uninstaller/uninstaller_ytdlp.py
+++ b/packages/uninstaller/uninstaller_ytdlp.py
@@ -1,16 +1,14 @@
 import os
 from packages.core import path #unified path function
 def uninstaller_wahiddl_ytdlp_uninstall():
-    os.chdir (path.wahiddl_folder())
-    if os.path.isfile (path.wahiddl_ytdlp()) == True:
+    try:
         os.remove (path.wahiddl_ytdlp())
         print ("已刪除 yt-dlp.exe")
-    elif not os.path.isfile (path.wahiddl_ytdlp()) == True:
+    except:
         print ("不存在 yt-dlp.exe")
 def uninstaller_wahiddl_DEV_ytdlp_uninstall():
-    os.chdir (path.wahiddl_DEV_folder())
-    if os.path.isfile (path.wahiddl_DEV_ytdlp()) == True:
+    try:
         os.remove (path.wahiddl_DEV_ytdlp())
         print ("已刪除 yt-dlp.exe")
-    elif not os.path.isfile (path.wahiddl_DEV_ytdlp()) == True:
+    except:
         print ("不存在 yt-dlp.exe")

--- a/wahid-dl Dev Mode.py
+++ b/wahid-dl Dev Mode.py
@@ -1,6 +1,4 @@
-from packages.core import version_info
 from packages.function import wahiddl_devmode
-system_os = version_info.vi_platform()
 try:
     wahiddl_devmode.devmode()
 except:

--- a/wahid-dl Format Checking Tool.py
+++ b/wahid-dl Format Checking Tool.py
@@ -1,7 +1,5 @@
-from packages.core import version_info
 from packages.function import wahiddl_FCT
-system_os = version_info.vi_platform()
-try: 
+try:
     wahiddl_FCT.main()
 except:
     print ("不支援的平台")

--- a/wahid-dl Tool.py
+++ b/wahid-dl Tool.py
@@ -6,7 +6,7 @@ import glob
 import re
 import importlib
 
-version_outline = "[Develop]v6.1.20250827.1-Python"
+version_outline = "[Develop]v6.1.20250827.2-Python"
 
 def wahiddl_installer_without_packages():
     if os.path.exists ("C:\\wahid-dl"):

--- a/wahid-dl Tool.py
+++ b/wahid-dl Tool.py
@@ -6,7 +6,7 @@ import glob
 import re
 import importlib
 
-version_outline = "[Stable]v6.0.20250627.1-Python"
+version_outline = "[Develop]v6.1.20250826.1-Python"
 
 def wahiddl_installer_without_packages():
     if os.path.exists ("C:\\wahid-dl"):
@@ -276,11 +276,11 @@ if sys.platform == "win32":
                     print ("請重新輸入正確選項！")
     current_file_path = os.path.abspath(__file__)
     if os.path.exists ("C:\\wahid-dl\\packages"):
-        if current_file_path == 'C:\\wahid-dl\\wahid-dl Tool.py' or current_file_path == 'C:\\wahid-dl DEV\\wahid-dl Tool.py':
+        if current_file_path == 'C:\\wahid-dl\\wahid-dl Tool.py' or current_file_path == 'C:\\wahid-dl DEV\\wahid-dl Tool.py': #enable or disable this line to control packages mechanism when Debugging
                 wahiddl_tool = importlib.import_module("packages.function.wahiddl_tool")
                 wahiddl_tool.wahiddl_tool_windows_x64()
-        else:
-            main()
+        else: #enable or disable this line to control packages mechanism when Debugging
+            main() #enable or disable this line to control packages mechanism when Debugging
     else:
         main()
     input ()

--- a/wahid-dl Tool.py
+++ b/wahid-dl Tool.py
@@ -6,7 +6,7 @@ import glob
 import re
 import importlib
 
-version_outline = "[Develop]v6.1.20250826.1-Python"
+version_outline = "[Develop]v6.1.20250827.1-Python"
 
 def wahiddl_installer_without_packages():
     if os.path.exists ("C:\\wahid-dl"):

--- a/wahid-dl Tool.py
+++ b/wahid-dl Tool.py
@@ -6,7 +6,7 @@ import glob
 import re
 import importlib
 
-version_outline = "[Develop]v6.1.20250827.2-Python"
+version_outline = "[Stable]v6.2.20251227.1-Python"
 
 def wahiddl_installer_without_packages():
     if os.path.exists ("C:\\wahid-dl"):

--- a/wahid-dl Tool.py
+++ b/wahid-dl Tool.py
@@ -85,20 +85,20 @@ def ffmpeg_installer_without_packages():
     os.chdir ("C:\\wahid-dl")
     # 移除舊有ffmpeg安裝方式之檔案
     # 移除舊式FFmpeg安裝之舊版
-    if os.path.isfile ("C:\\wahid-dl\\ffmpeg.exe") == True:
+    try:
         os.remove ("C:\\wahid-dl\\ffmpeg.exe")
         print ("已刪除舊式舊版的 ffmpeg.exe")
-    else:
+    except:
         print ("已不存在舊式舊版 ffmpeg.exe")
-    if os.path.isfile ("C:\\wahid-dl\\ffplay.exe") == True:
+    try:
         os.remove ("C:\\wahid-dl\\ffplay.exe")
         print ("已刪除舊式舊版的 ffplay.exe")
-    else:
+    except:
         print ("已不存在舊式舊版 ffplay.exe")
-    if os.path.isfile ("C:\\wahid-dl\\ffprobe.exe") == True:
+    try:
         os.remove ("C:\\wahid-dl\\ffprobe.exe")
         print ("已刪除舊式舊版的 ffprobe.exe")
-    else:
+    except:
         print ("已不存在舊式舊版 ffprobe.exe")
     # 新式FFmpeg安裝，包括系統環境變數設定
     os.chdir ("C:\\")
@@ -124,20 +124,20 @@ def ffmpeg_installer_without_packages():
                 ffmpeg_download_need = "0"
             else:
                 # 移除新式舊版ffmpeg.exe, ffplay.exe, ffprobe.exe
-                if os.path.isfile ("C:\\FFmpeg\\ffmpeg.exe") == True:
+                try:
                     os.remove ("C:\\FFmpeg\\ffmpeg.exe")
                     print ("已刪除新式舊版的 ffmpeg.exe")
-                else:
+                except:
                     print ("已不存在新式舊版 ffmpeg.exe")
-                if os.path.isfile ("C:\\FFmpeg\\ffplay.exe") == True:
+                try:
                     os.remove ("C:\\FFmpeg\\ffplay.exe")
                     print ("已刪除新式舊版的 ffplay.exe")
-                else:
+                except:
                     print ("已不存在新式舊版 ffplay.exe")
-                if os.path.isfile ("C:\\FFmpeg\\ffprobe.exe") == True:
+                try:
                     os.remove ("C:\\FFmpeg\\ffprobe.exe")
                     print ("已刪除新式舊版的 ffprobe.exe")
-                else:
+                except:
                     print ("已不存在新式舊版 ffprobe.exe")
                 ffmpeg_download_need = "1"
     while ffmpeg_download_need == "1":
@@ -159,7 +159,8 @@ def ffmpeg_installer_without_packages():
         for ffmpeg_exe_file in ffmpeg_exe_files:
             shutil.move (ffmpeg_exe_file, ffmpeg_dst_folder)
         # FFmpeg系統環境變數設定
-        os.system ('setx PATH "FFmpeg;C:\\FFmpeg\\"')
+        #os.system ('setx PATH "FFmpeg;C:\\FFmpeg\\"')
+        #NOTICE: A severe flaw exists that could potentially lead to the removal of all system environment variables.
         ffmpeg_updates_file_path = "C:\\FFmpeg\\ffmpeg.zip"
         if os.path.isfile (ffmpeg_updates_file_path) == True:
             os.remove (ffmpeg_updates_file_path)
@@ -302,11 +303,11 @@ elif sys.platform == "linux":
             elif userinput_judge == False:
                 if userinput.startswith("START") == True:
                     print ("Start the installer")
-                    os.system ('sudo apt install pipx')
+                    #os.system ('sudo apt install pipx')
                     os.system ('sudo apt install opus-tools')
                     os.system ('sudo apt install ffmpeg')
-                    os.system ('pipx ensurepath')
-                    os.system ('pipx install yt-dlp --force')
+                    #os.system ('pipx ensurepath')
+                    #os.system ('pipx install yt-dlp --force')
                 else:
                     print ("Please re-enter the correct options!")
         while mode == "0":

--- a/wahid-dl Tool.py
+++ b/wahid-dl Tool.py
@@ -114,7 +114,7 @@ def ffmpeg_installer_without_packages():
             print (f"新式 {ffmpeg_folder_name} 資料夾已存在")
             # 檢查 FFmpeg 版本
             # FFmpeg Version Number，變動需要更新
-            ffmpeg_exact_version_number = "7.1.1"
+            ffmpeg_exact_version_number = "8.0.1"
             ffmpeg_version_org_output = subprocess.getoutput ("ffmpeg -version")
             ffmpeg_version_detail = re.search(r'ffmpeg version (\d+\.\d+(?:\.\d+)?)', ffmpeg_version_org_output)
             if ffmpeg_version_detail:
@@ -144,7 +144,7 @@ def ffmpeg_installer_without_packages():
         print ("開始下載 FFmpeg")
         os.chdir ("C:\\FFmpeg")
         # FFmpeg Version Number，變動需要更新
-        os.system ("curl -L -o ffmpeg.zip https://github.com/GyanD/codexffmpeg/releases/download/7.1.1/ffmpeg-7.1.1-full_build.zip")
+        os.system ("curl -L -o ffmpeg.zip https://github.com/GyanD/codexffmpeg/releases/download/8.0.1/ffmpeg-8.0.1-full_build.zip")
         FFmpegunzip_folder_name = "FFmpeg-unzip"
         if not os.path.exists (FFmpegunzip_folder_name):
             os.mkdir (FFmpegunzip_folder_name)
@@ -153,7 +153,7 @@ def ffmpeg_installer_without_packages():
             print (f"'{FFmpegunzip_folder_name}' 資料夾已存在")
         os.system ('tar -zxvf ffmpeg.zip -C "C:\\FFmpeg\\FFmpeg-unzip"')
         # FFmpeg Version Number，變動需要更新
-        ffmpeg_updatesfiles_folder = "C:\\FFmpeg\\FFmpeg-unzip\\ffmpeg-7.1.1-full_build\\bin\\"
+        ffmpeg_updatesfiles_folder = "C:\\FFmpeg\\FFmpeg-unzip\\ffmpeg-8.0.1-full_build\\bin\\"
         ffmpeg_dst_folder = "C:\\FFmpeg\\"
         ffmpeg_exe_files = glob.glob (ffmpeg_updatesfiles_folder + "*.exe")
         for ffmpeg_exe_file in ffmpeg_exe_files:

--- a/wahid-dl for Audio.py
+++ b/wahid-dl for Audio.py
@@ -1,6 +1,4 @@
-from packages.core import version_info
 from packages.function import wahiddl_audio
-system_os = version_info.vi_platform()
 try:
     wahiddl_audio.main()
 except:

--- a/wahid-dl for Cookies Support.py
+++ b/wahid-dl for Cookies Support.py
@@ -1,6 +1,4 @@
-from packages.core import version_info
 from packages.function import wahiddl_CS
-system_os = version_info.vi_platform()
 try: 
     wahiddl_CS.main()
 except:

--- a/wahid-dl for List.py
+++ b/wahid-dl for List.py
@@ -1,6 +1,4 @@
-from packages.core import version_info
 from packages.function import wahiddl_list
-system_os = version_info.vi_platform()
 try:
     wahiddl_list.main()
 except:

--- a/wahid-dl for Live.py
+++ b/wahid-dl for Live.py
@@ -1,6 +1,4 @@
-from packages.core import version_info
 from packages.function import wahiddl_live
-system_os = version_info.vi_platform()
 try: 
     wahiddl_live.main()
 except:

--- a/wahid-dl for Quality Selection.py
+++ b/wahid-dl for Quality Selection.py
@@ -1,6 +1,4 @@
-from packages.core import version_info
 from packages.function import wahiddl_QS
-system_os = version_info.vi_platform()
 try: 
     wahiddl_QS.main()
 except:

--- a/wahid-dl for Subtitle.py
+++ b/wahid-dl for Subtitle.py
@@ -1,6 +1,4 @@
-from packages.core import version_info
 from packages.function import wahiddl_subtitle
-system_os = version_info.vi_platform()
 try:
     wahiddl_subtitle.main()
 except:

--- a/wahid-dl.py
+++ b/wahid-dl.py
@@ -1,8 +1,8 @@
-from packages.core import version_info
+#from packages.core import version_info
 from packages.function import wahiddl
-system_os = version_info.vi_platform()
-try: 
-    wahiddl.main()
+#system_os = version_info.vi_platform() # from import 'version_info' checking current platform and
+try:
+    wahiddl.main() # from packages.function import the 'wahiddl'and execute its function main()
 except:
     print ("不支援的平台")
 input()

--- a/wahid-dl.py
+++ b/wahid-dl.py
@@ -1,6 +1,4 @@
-#from packages.core import version_info
 from packages.function import wahiddl
-#system_os = version_info.vi_platform() # from import 'version_info' checking current platform and
 try:
     wahiddl.main() # from packages.function import the 'wahiddl'and execute its function main()
 except:


### PR DESCRIPTION
- fix: Fixed a module call error that caused a crash 
- fix: Corrected the version judgment RE 
- fix: Removed platform check dependency and corrected the display of version information 
- fix: Fixed incorrect text 
- fix: Fixed the wrong loop 
- fix: Corrected the return value method 
- fix: Fixed incorrect display 
- fix: Corrected the incorrect judgment leading to incorrect execution 
- fix: Fixed yt-dlp not installing in wahid-dl development channel 
- fix: Modified the judgment value to Boolean value
- fix: Fixed install and uninstall functionality 
- fix: Fixed folders not being removed by uninstaller
- fix: Fixed incorrect folder removal 
- fix: Temporarily remove system variable setting 
- fix: Updated FFmpeg version 
- feat: Removed support for Windows based on batchfile 
- feat: Simplified the code and adjusted the functions 
- feat: Changed to use unified packages 
- feat: Removed the installer build tool 
- feat: Call the new unified UI/UX 
- feat: Called the unified function 
- style: Changed the display text from "DEV" to "Develop Channel"
- perf: Optimized code and function 
- perf: Emporarily removed system variable setting and pipx install on Linux 